### PR TITLE
Add GitHub icon link in footer

### DIFF
--- a/dev.log
+++ b/dev.log
@@ -1,0 +1,21 @@
+
+> r3f-ogp-image@0.1.0 dev
+> next dev -p 54839
+
+  ▲ Next.js 14.2.23
+  - Local:        http://localhost:54839
+
+ ✓ Starting...
+Attention: Next.js now collects completely anonymous telemetry regarding usage.
+This information is used to shape Next.js' roadmap and prioritize features.
+You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
+https://nextjs.org/telemetry
+
+   Downloading swc package @next/swc-linux-arm64-gnu...
+   Downloading swc package @next/swc-linux-arm64-musl...
+ ✓ Ready in 12.5s
+ ○ Compiling / ...
+ ✓ Compiled / in 22.4s (2297 modules)
+ GET / 200 in 24644ms
+ ✓ Compiled in 2.4s (1456 modules)
+ ✓ Compiled in 177ms (1442 modules)

--- a/src/screens/TopScreen/index.tsx
+++ b/src/screens/TopScreen/index.tsx
@@ -163,7 +163,11 @@ export const TopScreen = () => {
         </div>
 
         <footer className="text-center text-gray-500 text-sm">
-          Created by <a href="https://x.com/sawa_zen" target="_blank" rel="noopener noreferrer">@sawa-zen</a>
+          Created by <a href="https://x.com/sawa_zen" target="_blank" rel="noopener noreferrer">@sawa-zen</a> | <a href="https://github.com/sawa-zen/r3f-ogp-image" target="_blank" rel="noopener noreferrer">
+            <svg xmlns="http://www.w3.org/2000/svg" className="inline-block w-6 h-6" fill="currentColor" viewBox="0 0 24 24">
+              <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.728-4.042-1.61-4.042-1.61-.546-1.385-1.333-1.754-1.333-1.754-1.089-.744.084-.729.084-.729 1.205.084 1.84 1.236 1.84 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.418-1.305.762-1.605-2.665-.3-5.466-1.335-5.466-5.93 0-1.31.47-2.38 1.236-3.22-.124-.303-.536-1.523.117-3.176 0 0 1.008-.322 3.3 1.23.957-.266 1.98-.399 3-.405 1.02.006 2.043.139 3 .405 2.29-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.873.118 3.176.77.84 1.236 1.91 1.236 3.22 0 4.61-2.807 5.625-5.48 5.92.43.37.823 1.102.823 2.222 0 1.606-.015 2.896-.015 3.286 0 .32.216.694.825.576C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+            </svg>
+          </a>
         </footer>
       </div>
     </div>


### PR DESCRIPTION
This PR updates the repository footer to include a GitHub icon link that points to the repository.